### PR TITLE
Add unsupported/experimental OCaml 5.0.0+BER

### DIFF
--- a/packages/base-metaocaml-ocamlfind/base-metaocaml-ocamlfind.5.0.0+ber-unsupported/files/META
+++ b/packages/base-metaocaml-ocamlfind/base-metaocaml-ocamlfind.5.0.0+ber-unsupported/files/META
@@ -1,0 +1,7 @@
+description = "Extra libraries for MetaOCaml"
+directory = "+"
+requires = "compiler-libs.common"
+requires(byte) = "compiler-libs.bytecomp compiler-libs.toplevel"
+requires(native) = "compiler-libs.optcomp dynlink"
+archive(byte) = "metalib.cma berstart.cmo"
+archive(native) = "codelib.cmx runnative.cmx"

--- a/packages/base-metaocaml-ocamlfind/base-metaocaml-ocamlfind.5.0.0+ber-unsupported/files/metaocaml.conf
+++ b/packages/base-metaocaml-ocamlfind/base-metaocaml-ocamlfind.5.0.0+ber-unsupported/files/metaocaml.conf
@@ -1,0 +1,2 @@
+ocamlc(metaocaml) = "metaocamlc"
+ocamlmktop(metaocaml) = "metaocamlmktop"

--- a/packages/base-metaocaml-ocamlfind/base-metaocaml-ocamlfind.5.0.0+ber-unsupported/files/metaocaml.native.conf
+++ b/packages/base-metaocaml-ocamlfind/base-metaocaml-ocamlfind.5.0.0+ber-unsupported/files/metaocaml.native.conf
@@ -1,0 +1,3 @@
+ocamlc(metaocaml) = "metaocamlc"
+ocamlopt(metaocaml) = "metaocamlopt"
+ocamlmktop(metaocaml) = "metaocamlmktop"

--- a/packages/base-metaocaml-ocamlfind/base-metaocaml-ocamlfind.5.0.0+ber-unsupported/opam
+++ b/packages/base-metaocaml-ocamlfind/base-metaocaml-ocamlfind.5.0.0+ber-unsupported/opam
@@ -1,0 +1,29 @@
+opam-version: "2.0"
+maintainer: "yallop@gmail.com"
+authors: ["Jeremy Yallop"]
+license: "MIT"
+depopts: ["ocamlfind"]
+homepage: "https://github.com/ocaml/opam-repository/tree/master/packages/base-metaocaml-ocamlfind/base-metaocaml-ocamlfind.base"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
+install: [
+  ["mkdir" "-p" "%{lib}%/findlib.conf.d/"] {ocamlfind:installed}
+  ["ocamlfind" "install" "metaocaml" "META"] {ocamlfind:installed}
+  ["cp" "metaocaml.native.conf" "%{lib}%/findlib.conf.d/metaocaml.conf"]
+    {ocamlfind:installed}
+]
+remove: [
+  [ "rm" "-f" "%{lib}%/findlib.conf.d/metaocaml.conf" ]
+  ["ocamlfind" "remove" "metaocaml"] {ocamlfind:installed}
+]
+synopsis: "Findlib toolchain configuration for MetaOCaml"
+depends: [
+  "ocaml"
+  "ocaml-variants"
+    {= "5.0.0+ber-unsupported" }
+]
+flags: light-uninstall
+extra-files: [
+  ["metaocaml.native.conf" "md5=2dc60223831dd583abab63220c6ed6ff"]
+  ["metaocaml.conf" "md5=c3e36877739c3147e3efecd5c3698473"]
+  ["META" "md5=e450da6f2b87c1291ea23d6a396bffa5"]
+]

--- a/packages/ocaml-variants/ocaml-variants.5.0.0+ber-unsupported/opam
+++ b/packages/ocaml-variants/ocaml-variants.5.0.0+ber-unsupported/opam
@@ -1,0 +1,105 @@
+opam-version: "2.0"
+name: "ocaml-variants"
+version: "5.0.0+ber-unsupported"
+synopsis: "OCaml 5.0.0 with BER-N114 patchset"
+maintainer: "yallop@gmail.com"
+authors: [
+  "Xavier Leroy"
+  "Damien Doligez"
+  "Alain Frisch"
+  "Jacques Garrigue"
+  "Didier Rémy"
+  "Jérôme Vouillon"
+  "Oleg Kiselyov"
+]
+license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
+homepage: "http://okmij.org/ftp/ML/MetaOCaml.html"
+bug-reports: "https://github.com/ocaml/opam-repository/issues"
+depends: [
+  "ocaml" {= "5.0.0" & post}
+  "base-unix" {post}
+  "base-bigarray" {post}
+  "base-threads" {post}
+  "base-metaocaml-ocamlfind" {post}
+]
+depopts: [
+  "ocaml-option-32bit"
+  "ocaml-option-afl"
+  "ocaml-option-bytecode-only"
+  "ocaml-option-default-unsafe-string"
+  "ocaml-option-no-flat-float-array"
+  "ocaml-option-flambda"
+  "ocaml-option-fp"
+  "ocaml-option-musl"
+  "ocaml-option-static"
+  "ocaml-option-nnp"
+  "ocaml-option-nnpchecker"
+]
+conflict-class: "ocaml-core-compiler"
+available: !(os = "macos" & arch = "arm64")
+flags: compiler
+setenv: CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"
+build: [
+  [
+    "./configure"
+    "--prefix=%{prefix}%"
+    "--docdir=%{doc}%/ocaml"
+    "-C"
+    "--with-afl" {ocaml-option-afl:installed}
+    "--disable-native-compiler" {ocaml-option-bytecode-only:installed}
+    "--disable-force-safe-string"
+      {ocaml-option-default-unsafe-string:installed}
+    "DEFAULT_STRING=unsafe" {ocaml-option-default-unsafe-string:installed}
+    "--disable-flat-float-array" {ocaml-option-no-flat-float-array:installed}
+    "--enable-flambda" {ocaml-option-flambda:installed}
+    "--enable-frame-pointers" {ocaml-option-fp:installed}
+    "--disable-naked-pointers" {ocaml-option-nnp:installed}
+    "--enable-naked-pointers-checker" {ocaml-option-nnpchecker:installed}
+    "CC=cc"
+      {!ocaml-option-32bit:installed & !ocaml-option-musl:installed &
+       (os = "openbsd" | os = "macos")}
+    "CC=musl-gcc" {ocaml-option-musl:installed & os-distribution != "alpine"}
+    "CFLAGS=-Os" {ocaml-option-musl:installed}
+    "CC=gcc -m32" {ocaml-option-32bit:installed & os = "linux"}
+    "CC=gcc -Wl,-read_only_relocs,suppress -arch i386 -m32"
+      {ocaml-option-32bit:installed & os = "macos"}
+    "ASPP=cc -c"
+      {!ocaml-option-32bit:installed & !ocaml-option-musl:installed &
+       (os = "openbsd" | os = "macos")}
+    "ASPP=musl-gcc -c"
+      {ocaml-option-musl:installed & os-distribution != "alpine"}
+    "ASPP=gcc -m32 -c" {ocaml-option-32bit:installed & os = "linux"}
+    "ASPP=gcc -arch i386 -m32 -c"
+      {ocaml-option-32bit:installed & os = "macos"}
+    "AS=as --32" {ocaml-option-32bit:installed & os = "linux"}
+    "AS=as -arch i386" {ocaml-option-32bit:installed & os = "macos"}
+    "--host=i386-linux" {ocaml-option-32bit:installed & os = "linux"}
+    "--host=i386-apple-darwin13.2.0"
+      {ocaml-option-32bit:installed & os = "macos"}
+    "PARTIALLD=ld -r -melf_i386"
+      {ocaml-option-32bit:installed & os = "linux"}
+    "LIBS=-static" {ocaml-option-static:installed}
+    "--disable-warn-error"
+  ]
+  [make "-j%{jobs}%"]
+]
+install: [
+  [make "-i" "install"]
+  [make "-C" "ber-metaocaml-114" "install" "install.opt"]
+]
+post-messages: [
+  """\
+A failure in the middle of the build may be caused by build parallelism
+   (enabled by default).
+   Please file a bug report at https://github.com/ocaml/opam-repository/issues"""
+    {failure & jobs > "1"}
+  """\
+You can try installing again including --jobs=1
+   to force a sequential build instead."""
+    {failure & jobs > "1" & opam-version >= "2.0.5"}
+]
+dev-repo: "git+https://github.com/metaocaml/ber-metaocaml.git#ber-n114"
+url {
+  src: "https://github.com/yallop/ocaml/archive/17fc2c2f.tar.gz"
+  checksum: "md5=8fccaa3490f56614c417cdd1c28a1209"
+}


### PR DESCRIPTION
A naive merge of the BER-N114 patchset onto OCaml 5.0.0.